### PR TITLE
makefile: check Go formatting

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
+      - name: Lint
+        run: make shellcheck gofmt
+        if: runner.os == 'Linux'
       - name: Create version file
         run: make version
-      - name: Lint
+      - name: Go Lint
         uses: golangci/golangci-lint-action@v6
       - name: Build
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,16 @@
 all: lint build
 
 .PHONY: lint
-lint: version
+lint: shellcheck gofmt version
 	@golangci-lint run
+
+.PHONY: shellcheck
+shellcheck:
+	@find . -name "*.sh" -exec shellcheck {} +
+
+.PHONY: gofmt
+gofmt:
+	@./ci/gofmt.sh .
 
 .PHONY: version
 version:

--- a/ci/gofmt.sh
+++ b/ci/gofmt.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+DIR=$1
+MALFORMATTED_FILES=$(gofmt -l "$DIR")
+if [[ -z "$MALFORMATTED_FILES" ]]; then
+    exit 0
+fi
+printf "Malformatted files found:\n%s\n\n" "$MALFORMATTED_FILES"
+gofmt -d "$DIR"
+exit 1


### PR DESCRIPTION
This commit adds make targets for checking that Go formatting is correct
according to the `gofmt` rules.

Unfortunately, `gofmt` doesn't have a native `--check` mode. So this
commit introduces the `ci/gofmt.sh` script that imitates check behavior
using existing gofmt options.
