### PR TITLE
github: run the build workflow periodically

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,8 @@ on:
       - master
       - "**-ci"
   pull_request:
+  schedule:
+    - cron: "10 23 * * 3"
 
 jobs:
   build:


### PR DESCRIPTION
This commit adds a cron schedule to the Build workflow. This is done to
pick up latest `golangci-lint` versions as they get released and detect
any new lint issues early.

The schedule is arbitrarily chosen based on the date of this commit,
Wed Oct 23. So it runs at 11:10 PM every Wednesday.
