### PR TITLE
Enable `unparam` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+---
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unparam
+    - unused

--- a/create.go
+++ b/create.go
@@ -115,7 +115,7 @@ func reviewersLine(pr ApiPullRequest) string {
 	return strings.Join(reviewers, " ")
 }
 
-func newPrComment(pr PullRequest, apiPr ApiPullRequest, newRevision Revision, revisions []Revision) (path string, err error) {
+func newPrComment(apiPr ApiPullRequest, newRevision Revision, revisions []Revision) (path string, err error) {
 	links, err := linkLines(newRevision, revisions)
 	if err != nil {
 		return "", err
@@ -220,7 +220,7 @@ func createRevision(args CreateArgs) error {
 		return err
 	}
 
-	path, err := newPrComment(pr, apiPr, newRev, revisions)
+	path, err := newPrComment(apiPr, newRev, revisions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

To catch unused parameters in functions, like was fixed in 5b6d90cb02.
