### PR TITLE
Add revision comparison subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ gh pr-revision --help
 
 ```text
 GitHub CLI extension for pull request revisions
-v0.0.1
+v0.2.0-7-gc8e5dab157
 Usage: gh-pr-revision <command> [<args>]
 
 Options:
@@ -41,6 +41,8 @@ Options:
 
 Commands:
   create                 create revision
+  diff                   compare revisions with 'git diff'
+  difftool               compare revisions with 'git difftool'
   list                   list revisions
   show                   show revision
 ```

--- a/common.go
+++ b/common.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -141,4 +142,13 @@ func editUserComment(ioStreams *iostreams.IOStreams) (string, error) {
 	}
 
 	return string(bytes.TrimPrefix(data, bom)), nil
+}
+
+func hasCommit(hash string) bool {
+	args := []string{"cat-file", "-e", hash}
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	if err := cmd.Run(); err == nil {
+		return true
+	}
+	return false
 }

--- a/diff.go
+++ b/diff.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+func diffRevisions(args DiffArgs, tool string) error {
+	ioStreams := iostreams.System()
+	ioStreams.StartProgressIndicator()
+	defer ioStreams.StopProgressIndicator()
+
+	if args.From == args.To {
+		return fmt.Errorf("cannot compare same revision: %d", args.From)
+	}
+
+	pr, err := getPullRequest()
+	if err != nil {
+		return err
+	}
+	revisions, err := parseRevisions(pr)
+	if err != nil {
+		return err
+	}
+	if len(revisions) == 0 {
+		return fmt.Errorf("no revisions found")
+	}
+
+	var fromHash, toHash string
+	for _, r := range revisions {
+		if r.Number == args.From {
+			fromHash = r.Hash
+		} else if r.Number == args.To {
+			toHash = r.Hash
+		}
+	}
+	if args.From == 0 {
+		fromHash = revisions[0].BaseHash
+	}
+	if args.To == 0 {
+		toHash = revisions[0].BaseHash
+	}
+	if len(fromHash) == 0 {
+		return fmt.Errorf("FROM revision %d not found", args.From)
+	} else if len(toHash) == 0 {
+		return fmt.Errorf("TO revision %d not found", args.To)
+	}
+
+	if !hasCommit(fromHash) {
+		return fmt.Errorf("FROM hash not found, try 'git fetch': %s", fromHash)
+	}
+	if !hasCommit(toHash) {
+		return fmt.Errorf("TO hash not found, try 'git fetch': %s", toHash)
+	}
+
+	toolArgs := []string{tool}
+	if tool == "difftool" {
+		toolArgs = append(toolArgs, "--no-prompt")
+	}
+	toolArgs = append(toolArgs, fromHash)
+	toolArgs = append(toolArgs, toHash)
+
+	ioStreams.StopProgressIndicator()
+
+	cmd := exec.CommandContext(context.Background(), "git", toolArgs...)
+	cmd.Stdin = ioStreams.In
+	cmd.Stdout = ioStreams.Out
+	cmd.Stderr = ioStreams.ErrOut
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("'git %s' failed: %v", tool, err)
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,11 @@ type CreateArgs struct {
 	Edit      bool   `arg:"-e, --editor" help:"open an editor to add revision comment"`
 }
 
+type DiffArgs struct {
+	From uint64 `arg:"positional,required"`
+	To   uint64 `arg:"positional,required"`
+}
+
 type ListArgs struct {
 	Verbose bool `arg:"-v, --verbose" help:"enable verbose mode"`
 }
@@ -25,9 +30,11 @@ type ShowArgs struct {
 }
 
 type Args struct {
-	Create *CreateArgs `arg:"subcommand:create" help:"create revision"`
-	List   *ListArgs   `arg:"subcommand:list" help:"list revisions"`
-	Show   *ShowArgs   `arg:"subcommand:show" help:"show revision"`
+	Create   *CreateArgs `arg:"subcommand:create" help:"create revision"`
+	Diff     *DiffArgs   `arg:"subcommand:diff" help:"compare revisions with 'git diff'"`
+	DiffTool *DiffArgs   `arg:"subcommand:difftool" help:"compare revisions with 'git difftool'"`
+	List     *ListArgs   `arg:"subcommand:list" help:"list revisions"`
+	Show     *ShowArgs   `arg:"subcommand:show" help:"show revision"`
 }
 
 func (Args) Description() string {
@@ -68,6 +75,10 @@ func main() {
 	switch {
 	case args.Create != nil:
 		err = createRevision(*args.Create)
+	case args.Diff != nil:
+		err = diffRevisions(*args.Diff, "diff")
+	case args.DiffTool != nil:
+		err = diffRevisions(*args.DiffTool, "difftool")
 	case args.List != nil:
 		err = listRevisions(*args.List)
 	case args.Show != nil:


### PR DESCRIPTION

This PR adds 'diff' and 'difftool' subcommands that compare
revisions with 'git diff' and 'git difftool' correspondingly.
