### PR TITLE
vscode: add cSpell configuration

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2",
+    "language": "en",
+    "words": [
+        "hushsecurity",
+        "commitish",
+        "difftool",
+        "iostreams",
+        "shellquote",
+        "kballard",
+        "alexflint",
+        "errcheck",
+        "gosimple",
+        "govet",
+        "ineffassign",
+        "staticcheck",
+        "unparam",
+        "shellcheck",
+        "gofmt",
+        "golangci"
+    ],
+    "flagWords": []
+}


### PR DESCRIPTION
To teach the spell-checker a list of words that should always be
considered correct. Usually these are names, modules, packages and
tools.
