### PR TITLE
github: verify pull requests do not have merge commits

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,12 +17,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Linear PR history
+        if: github.event_name == 'pull_request'
+        uses: NexusPHP/no-merge-commits@v2.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
This is a preparation step for allowing merge commits into the master
branch. Merges of pull requests will be allowed under 2 conditions:

(a) a PR branch doesn't contain merge commits of its own
(b) a PR branch is rebased over master tip

Currently GitHub allows enforcement of (b) in branch protection rules [1].

Enforcement of (a) isn't currently automated by GitHub. Therefore, we
will enforce PR linear history as a build step in Build workflow, and we
will require the Build workflow to succeed to allow the PR merge.

This commit enforces PR linear history as a build step in Build
workflow. The rest is taken care of in repository settings.

[1] https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#require-status-checks-to-pass-before-merging
