### PR TITLE
dependabot: run gomod updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
Weekly seems to be too frequent becauce gh-cli updates about twice a
month.
