### PR TITLE
dependabot: run github-actions update monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: gomod
     directory: /
     schedule:


### PR DESCRIPTION
Initially I have set this to daily, but there is no need for such a
frequent check because it is not related to security alerts.
