### PR TITLE
create: print created revision number and pr comment url

### DIFF
--- a/common.go
+++ b/common.go
@@ -91,12 +91,12 @@ func revParse(ref string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func addPrComment(path string) error {
-	_, _, err := gh.Exec("pr", "comment", "-F", path)
+func addPrComment(path string) (string, error) {
+	output, _, err := gh.Exec("pr", "comment", "-F", path)
 	if err != nil {
-		return fmt.Errorf("'gh pr comment' failed: %v", err)
+		return "", fmt.Errorf("'gh pr comment' failed: %v", err)
 	}
-	return nil
+	return output.String(), nil
 }
 
 func editUserComment(ioStreams *iostreams.IOStreams) (string, error) {

--- a/create.go
+++ b/create.go
@@ -226,5 +226,15 @@ func createRevision(args CreateArgs) error {
 	}
 	defer os.Remove(path)
 
-	return addPrComment(path)
+	out, err := addPrComment(path)
+	if err != nil {
+		return err
+	}
+
+	ioStreams.StopProgressIndicator()
+
+	fmt.Printf("Revision %d\n", newRev.Number)
+	fmt.Printf("%s\n", out)
+
+	return nil
 }


### PR DESCRIPTION
This commit changes the `create` command to also print the created
revision number and add a link to the created pr comment.
