### PR TITLE
create: add `-m, --message` parameter

### DIFF
--- a/common.go
+++ b/common.go
@@ -99,7 +99,7 @@ func addPrComment(path string) (string, error) {
 	return strings.TrimSpace(output.String()), nil
 }
 
-func editUserComment(ioStreams *iostreams.IOStreams) (string, error) {
+func editUserComment(ioStreams *iostreams.IOStreams, message string) (string, error) {
 	tmpFile, err := os.CreateTemp("", "gh-pr-revision-user-comment.*.md")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary file: %v", err)
@@ -109,6 +109,12 @@ func editUserComment(ioStreams *iostreams.IOStreams) (string, error) {
 	if runtime.GOOS == "windows" {
 		if _, err := tmpFile.Write(bom); err != nil {
 			return "", fmt.Errorf("failed to write bom: %v", err)
+		}
+	}
+
+	if len(message) > 0 {
+		if _, err := tmpFile.WriteString(message); err != nil {
+			return "", fmt.Errorf("failed to write message: %v", err)
 		}
 	}
 

--- a/create.go
+++ b/create.go
@@ -201,13 +201,15 @@ func createRevision(args CreateArgs) error {
 	var body string
 	if args.Edit {
 		ioStreams.StopProgressIndicator()
-		if body, err = editUserComment(ioStreams); err != nil {
+		if body, err = editUserComment(ioStreams, args.Message); err != nil {
 			return err
 		}
 		ioStreams.StartProgressIndicator()
 		if len(body) == 0 {
 			return fmt.Errorf("empty revision comment: aborted")
 		}
+	} else {
+		body = args.Message
 	}
 
 	newRev, err := newRevision(hash, pr, revisions, body)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ var version string
 type CreateArgs struct {
 	Commitish string `arg:"-c, --commitish" help:"a commitish to associate the revision with (HEAD if omitted)"`
 	Edit      bool   `arg:"-e, --editor" help:"open an editor to add revision comment"`
+	Message   string `arg:"-m, --message" help:"add this as revision comment"`
 }
 
 type DiffArgs struct {


### PR DESCRIPTION
Opening an editor for every revision comment may be tedious, especially
for short comments.

This commit adds support for specifying revision comment on command line
using the following command:

    gh-pr-revision create -m "Short comment"

If combined with `-e` parameter the temporary file will be first
prepopulated with the comment.
