### PR TITLE
golangci: increase the timeout to 3m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 ---
+run:
+  timeout: 3m
+
 linters:
   enable:
     - errcheck


### PR DESCRIPTION
The Windows build fails on timeout.
