### PR TITLE
create: allow adding reviewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-12-16
+
+### Added
+
+- add `create -r <user-reviewer> -t <team-reviewer>` cli args to add reviewers at
+  revision creation time. This is especially handy at creation of the first revision
+  because one can omit the reviewers at PR creation and specify them only when
+  first revision is published.
+
 ## [0.5.0] - 2024-12-09
 
 ### Added
@@ -75,3 +84,4 @@ Initial release.
 [0.3.0]: https://github.com/hushsecurity/gh-pr-revision/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/hushsecurity/gh-pr-revision/compare/v0.3.0...v0.4.0
 [0.5.0]: https://github.com/hushsecurity/gh-pr-revision/compare/v0.4.0...v0.5.0
+[0.6.0]: https://github.com/hushsecurity/gh-pr-revision/compare/v0.5.0...v0.6.0

--- a/create.go
+++ b/create.go
@@ -220,6 +220,8 @@ func createRevision(args CreateArgs) error {
 
 	newRev.ExtendReviewers(revisions...)
 	newRev.ExtendReviewersFromApi(apiPr)
+	newRev.ExtendUserReviewers(args.UserReviewer...)
+	newRev.ExtendTeamReviewers(args.TeamReviewer...)
 
 	path, err := newPrComment(newRev, revisions)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -12,9 +12,11 @@ import (
 var version string
 
 type CreateArgs struct {
-	Commitish string `arg:"-c, --commitish" help:"a commitish to associate the revision with (HEAD if omitted)"`
-	Edit      bool   `arg:"-e, --editor" help:"open an editor to add revision comment"`
-	Message   string `arg:"-m, --message" help:"add this as revision comment"`
+	Commitish    string   `arg:"-c, --commitish" help:"a commitish to associate the revision with (HEAD if omitted)"`
+	Edit         bool     `arg:"-e, --editor" help:"open an editor to add revision comment"`
+	Message      string   `arg:"-m, --message" help:"add this as revision comment"`
+	UserReviewer []string `arg:"-r, --reviewer,separate" help:"add a user reviewer to the pull-request"`
+	TeamReviewer []string `arg:"-t, --team-reviewer,separate" help:"add a team reviewer to the pull-request"`
 }
 
 type DiffArgs struct {

--- a/revision.go
+++ b/revision.go
@@ -61,6 +61,18 @@ func (r *Revision) AddTeamReviewer(slug string) {
 	r.TeamReviewers = append(r.TeamReviewers, slug)
 }
 
+func (r *Revision) ExtendUserReviewers(reviewers ...string) {
+	for _, login := range reviewers {
+		r.AddUserReviewer(login)
+	}
+}
+
+func (r *Revision) ExtendTeamReviewers(reviewers ...string) {
+	for _, slug := range reviewers {
+		r.AddTeamReviewer(slug)
+	}
+}
+
 func (r *Revision) ExtendReviewers(revisions ...Revision) {
 	for _, other := range revisions {
 		for _, login := range other.UserReviewers {


### PR DESCRIPTION
Allow adding reviewers on command line.
This is handy when creating the first revision. If one forgot to add
reviwers in `gh pr create` now it is possibe to add them in `gh rvc`
that (usually) comes immediately after.
