### PR TITLE
golangci: increase timeout from 3 to 5 min

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 ---
 run:
-  timeout: 3m
+  timeout: 5m
 
 linters:
   enable:


### PR DESCRIPTION
To avoid build failures on Windows that happen from time to time.

For example, in [1] we see the folllowing error in Windows build only:

```
Running [D:\a\_temp\76458769-8910-4e91-9ce8-632ba3fb5e9e\golangci-lint-1.62.2-windows-amd64\golangci-lint run] in [D:\a\gh-pr-revision\gh-pr-revision] ...
  level=error msg="Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/packages: context deadline exceeded"
  level=error msg="Timeout exceeded: try increasing it by passing --timeout option"

  Error: golangci-lint exit with code 4
  Ran golangci-lint in 180519ms
```

[1] https://github.com/hushsecurity/gh-pr-revision/actions/runs/12402942912/job/34625480085
