### PR TITLE
create: add `-n, --no-review` knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2025-01-05
+
+### Added
+
+- Add `-n, --no-review` knob to `create` command.
+
+  This is handy when a PR is already approved but needs to be rebased over a fresh
+  `main` tip for merging. In this case we would like to add a revision because of the
+  rebase, but there is no need to request reviews because in most cases the PR will be
+  merged immediately after Build succeeds. If any changes are required after rebase
+  another revision can be created including review requests. This revision has a clean
+  diff because it doesn't include the rebase changes.
+
 ## [0.6.0] - 2024-12-16
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ type CreateArgs struct {
 	Message      string   `arg:"-m, --message" help:"add this as revision comment"`
 	UserReviewer []string `arg:"-r, --reviewer,separate" help:"add a user reviewer to the pull-request"`
 	TeamReviewer []string `arg:"-t, --team-reviewer,separate" help:"add a team reviewer to the pull-request"`
+	NoReview     bool     `arg:"-n, --no-review" help:"do not send review requests"`
 }
 
 type DiffArgs struct {


### PR DESCRIPTION
The new knob, when enabled, skips sending GitHub reviews.

This is handy when a PR is already approved but needs to be rebased over
fresh `main` tip. In this case we would like to send a revision with
"rebase only" message, but there is no need to send GitHub reviews
because the PR will be merged immediately after Build completes.

If any changes are required after rebase a new revision is created
including review requests. This revision has a clean diff because it
doesn't contain the rebase diff.

Note that `@` mentions of reviewers in revision comment are skipped too
(when `--no-review` is enabled).