### PR TITLE
Update to `golangci-lint v2`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create version file
         run: make version
       - name: Go Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
       - name: Build
         run: make build
       - name: Show version

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,22 @@
----
-run:
-  timeout: 5m
-
+version: "2"
 linters:
   enable:
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
     - unparam
-    - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/diff.go
+++ b/diff.go
@@ -31,9 +31,10 @@ func diffRevisions(args DiffArgs, tool string) error {
 
 	var fromHash, toHash string
 	for _, r := range revisions {
-		if r.Number == args.From {
+		switch r.Number {
+		case args.From:
 			fromHash = r.Hash
-		} else if r.Number == args.To {
+		case args.To:
 			toHash = r.Hash
 		}
 	}

--- a/revision.go
+++ b/revision.go
@@ -169,7 +169,7 @@ func parseBody(comment Comment) string {
 		lines = append(lines, line)
 	}
 
-	if !(startSeen && endSeen) {
+	if !startSeen || !endSeen {
 		return ""
 	}
 


### PR DESCRIPTION

Update code to conform to default v2 lint settings.
Update the workflow and conf file for v2 support.